### PR TITLE
[DF-1280] Use python:3.10-slim as Docker base image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,9 +1,7 @@
-FROM python:3.10.4-buster
+FROM python:3.10-slim
 
 RUN apt-get update
-RUN apt-get install -y ca-certificates
-
-RUN apt-get install -y libsodium23
+RUN apt-get install --no-install-recommends --yes git libsodium23
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING=UTF-8


### PR DESCRIPTION
## Overview

(copied from https://github.com/WebOfTrust/vLEI/pull/83)

Presently the vLEI project depends on Docker image _python:3.10.4-buster_, and consequently has **24 critical** vulnerabilities and **127 high** vulnerabilities, per the Snyk software security scanner. I seek to update the vLEI project to use a more recent image with fewer vulnerabilities: _python:3.10-slim_

Why use image python:3.10-slim?
- Maintain Python 3.10, because 3.11 is not necessarily backward compatible, and I haven't tested this.
- Buster is EOL, so should move to using latest Debian stable ("bookworm"), which might imply usage of image 3.10-bookworm.
- But we generally just want to use "latest Debian stable", even in the future when it is no longer bookworm. So instead of using 3.10-bookworm, select the image 3.10, which currently depends on bookworm but will later be upgraded to depend on the latest Debian stable.
- Why use the slim variant? Because 3.10-slim is smaller by a factor of 10, and would be expected to have fewer vulnerabilities, which is presently the case. To view details justifying this point, see:
 -- https://hub.docker.com/layers/library/python/3.10/images/sha256-4f7ca582d310c40d430ab6a17c46a0b360aee5987e0ef5aa155eeabc9ffa8393?context=explore
 -- https://hub.docker.com/layers/library/python/3.10-slim/images/sha256-9a97ede5d731252b42541a5d3ec60f6d4cd03747ca75315adc784ed864651c0e?context=repo&tab=vulnerabilities
 -- The 3.10-slim variant presently depends on debian:bookworm-slim, which removes man pages and a few other niceties.

## Packages

ca-certificates already present in newer Debian. git is not present, so need to install.

## Testing

I built the image and ran `pytest` in the image, per project instructions.

I retested the new image for vulnerabilities using Snyk CLI. After this change we now have 1 critical vulnerability introduced by compression library zlib1g. See details below.

```
$ time snyk container test --project-name=WebOfTrust/vLEI:container/Dockerfile --file=container/Dockerfile --severity-threshold=high sha256:7d198a4e7d7eb0a423d638e650653f893da8c9c086c9cac900e4519acb1278b1 | tee snyk-test-output_2.log

Testing sha256:7d198a4e7d7eb0a423d638e650653f893da8c9c086c9cac900e4519acb1278b1...

✗ Critical severity vulnerability found in zlib/zlib1g
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN12-ZLIB-6008963
  Introduced through: zlib/zlib1g@1:1.2.13.dfsg-1, git@1:2.39.2-1.1, util-linux/util-linux@2.38.1-5+b1, apt@2.6.1
  From: zlib/zlib1g@1:1.2.13.dfsg-1
  From: git@1:2.39.2-1.1 > zlib/zlib1g@1:1.2.13.dfsg-1
  From: util-linux/util-linux@2.38.1-5+b1 > zlib/zlib1g@1:1.2.13.dfsg-1
  and 7 more...
  Image layer: 'apt-get install --no-install-recommends --yes git libsodium23'



Organization:      provenant
Package manager:   deb
Target file:       container/Dockerfile
Project name:      WebOfTrust/vLEI:container/Dockerfile
Docker image:      sha256:7d198a4e7d7eb0a423d638e650653f893da8c9c086c9cac900e4519acb1278b1
Platform:          linux/amd64
Base image:        python:3.10-slim
Licenses:          enabled

Tested 123 dependencies for known issues, found 1 issue.

Base Image        Vulnerabilities  Severity
python:3.10-slim  46               1 critical, 0 high, 1 medium, 44 low

Recommendations for base image upgrade:

Minor upgrades
Base Image            Vulnerabilities  Severity
python:3.13.0a2-slim  45               1 critical, 0 high, 1 medium, 43 low

Alternative image types
Base Image                     Vulnerabilities  Severity
python:3.13.0a2-slim-bullseye  68               1 critical, 0 high, 0 medium, 67 low


Pro tip: use `--exclude-base-image-vulns` to exclude from display Docker base image vulnerabilities.

Snyk found some vulnerabilities in your image applications (Snyk searches for these vulnerabilities by default). See https://snyk.co/app-vulns for more information.

To remove these messages in the future, please run `snyk config set disableSuggestions=true`

Learn more: https://docs.snyk.io/products/snyk-container/getting-around-the-snyk-container-ui/base-image-detection

-------------------------------------------------------

Testing sha256:7d198a4e7d7eb0a423d638e650653f893da8c9c086c9cac900e4519acb1278b1...

Organization:      provenant
Package manager:   pip
Target file:       /usr/local/var/vLEI/requirements.txt
Project name:      WebOfTrust/vLEI:container/Dockerfile
Docker image:      sha256:7d198a4e7d7eb0a423d638e650653f893da8c9c086c9cac900e4519acb1278b1
Licenses:          enabled

✔ Tested sha256:7d198a4e7d7eb0a423d638e650653f893da8c9c086c9cac900e4519acb1278b1 for known issues, no vulnerable paths found.


Tested 2 projects, 1 contained vulnerable paths.




real	0m9.015s
user	0m3.913s
sys	0m0.884s
```
